### PR TITLE
Bugfix - ECDEV-1379 - Profile Card requests (Add & Update)

### DIFF
--- a/src/Message/CreateProfileCardRequest.php
+++ b/src/Message/CreateProfileCardRequest.php
@@ -9,7 +9,9 @@ class CreateProfileCardRequest extends AbstractProfileRequest
 
     public function getData()
     {
-        $data = array();
+        $data = array(
+            'comment' => $this->getComment()
+        );
 
         if ($this->getCard()) {
             $this->getCard()->validate();

--- a/src/Message/CreateProfileCardRequest.php
+++ b/src/Message/CreateProfileCardRequest.php
@@ -23,6 +23,10 @@ class CreateProfileCardRequest extends AbstractProfileRequest
             );
         }
 
+        if ($this->getToken()) {
+            $data['token'] = $this->getToken();
+        }
+
         return $data;
     }
 

--- a/src/Message/CreateProfileCardRequest.php
+++ b/src/Message/CreateProfileCardRequest.php
@@ -13,7 +13,7 @@ class CreateProfileCardRequest extends AbstractProfileRequest
         $this->getCard()->validate();
 
         if ($this->getCard()) {
-            $data = array(
+            $data['card'] = array(
                 'number' => $this->getCard()->getNumber(),
                 'name' => $this->getCard()->getName(),
                 'expiry_month' => $this->getCard()->getExpiryDate('m'),

--- a/src/Message/CreateProfileCardRequest.php
+++ b/src/Message/CreateProfileCardRequest.php
@@ -10,9 +10,10 @@ class CreateProfileCardRequest extends AbstractProfileRequest
     public function getData()
     {
         $data = array();
-        $this->getCard()->validate();
 
         if ($this->getCard()) {
+            $this->getCard()->validate();
+
             $data['card'] = array(
                 'number' => $this->getCard()->getNumber(),
                 'name' => $this->getCard()->getName(),

--- a/tests/Message/CreateProfileCardRequestTest.php
+++ b/tests/Message/CreateProfileCardRequestTest.php
@@ -63,6 +63,19 @@ class CreateProfileCardRequestTest extends TestCase
         $this->assertSame($card['firstName'] . ' ' . $card['lastName'], $data['card']['name']);
     }
 
+    public function testToken()
+    {
+        $token = array(
+            'name' => 'token-test-name',
+            'code' => 'token-test-code'
+        );
+
+        $this->assertSame($this->request, $this->request->setToken($token));
+        $this->assertSame($token, $this->request->getToken());
+        $data = $this->request->getData();
+        $this->assertSame($token, $data['token']);
+    }
+
     public function testHttpMethod()
     {
         $this->assertSame('POST', $this->request->getHttpMethod());

--- a/tests/Message/CreateProfileCardRequestTest.php
+++ b/tests/Message/CreateProfileCardRequestTest.php
@@ -50,11 +50,11 @@ class CreateProfileCardRequestTest extends TestCase
         $card = $this->getValidCard();
         $this->assertSame($this->request, $this->request->setCard($card));
         $data = $this->request->getData();
-        $this->assertSame($card['number'], $data['number']);
-        $this->assertSame($card['cvv'], $data['cvd']);
-        $this->assertSame(sprintf("%02d", $card['expiryMonth']), $data['expiry_month']);
-        $this->assertSame(substr($card['expiryYear'], -2), $data['expiry_year']);
-        $this->assertSame($card['firstName'] . ' ' . $card['lastName'], $data['name']);
+        $this->assertSame($card['number'], $data['card']['number']);
+        $this->assertSame($card['cvv'], $data['card']['cvd']);
+        $this->assertSame(sprintf("%02d", $card['expiryMonth']), $data['card']['expiry_month']);
+        $this->assertSame(substr($card['expiryYear'], -2), $data['card']['expiry_year']);
+        $this->assertSame($card['firstName'] . ' ' . $card['lastName'], $data['card']['name']);
     }
 
     public function testHttpMethod()

--- a/tests/Message/CreateProfileCardRequestTest.php
+++ b/tests/Message/CreateProfileCardRequestTest.php
@@ -45,6 +45,12 @@ class CreateProfileCardRequestTest extends TestCase
         $this->assertSame('https://www.beanstream.com/api/v1/profiles/' . $this->request->getProfileId(). '/cards', $this->request->getEndpoint());
     }
 
+    public function testComment()
+    {
+        $this->assertSame($this->request, $this->request->setComment('test'));
+        $this->assertSame('test', $this->request->getComment());
+    }
+
     public function testCard()
     {
         $card = $this->getValidCard();

--- a/tests/Message/UpdateProfileCardRequestTest.php
+++ b/tests/Message/UpdateProfileCardRequestTest.php
@@ -51,8 +51,16 @@ class UpdateProfileCardRequestTest extends TestCase
 
     public function testCard()
     {
+        $this->request->setProfileId('8F10Ab54FC434b71972cF2E442c0fb4f');
+        $this->request->setCardId('1');
         $card = $this->getValidCard();
         $this->assertSame($this->request, $this->request->setCard($card));
+        $data = $this->request->getData();
+        $this->assertSame($card['number'], $data['card']['number']);
+        $this->assertSame($card['cvv'], $data['card']['cvd']);
+        $this->assertSame(sprintf("%02d", $card['expiryMonth']), $data['card']['expiry_month']);
+        $this->assertSame(substr($card['expiryYear'], -2), $data['card']['expiry_year']);
+        $this->assertSame($card['firstName'] . ' ' . $card['lastName'], $data['card']['name']);
     }
 
     public function testHttpMethod()

--- a/tests/Message/UpdateProfileCardRequestTest.php
+++ b/tests/Message/UpdateProfileCardRequestTest.php
@@ -12,6 +12,20 @@ class UpdateProfileCardRequestTest extends TestCase
         $this->request->initialize();
     }
 
+    public function testSendSuccess()
+    {
+        $this->request->setProfileId('9ba60541d32648B1A3581670123dF2Ef');
+        $this->request->setCardId('1');
+        $card = $this->getValidCard();
+        $this->assertSame($this->request, $this->request->setCard($card));
+        $this->setMockHttpResponse('UpdateProfileCardSuccess.txt');
+        $response = $this->request->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame(1, $response->getCode());
+        $this->assertSame('Operation Successful', $response->getMessage());
+        $this->assertSame('9ba60541d32648B1A3581670123dF2Ef', $response->getCustomerCode());
+    }
+
     public function testEndpoint()
     {
         $this->assertSame($this->request, $this->request->setProfileId('1'));

--- a/tests/Message/UpdateProfileCardRequestTest.php
+++ b/tests/Message/UpdateProfileCardRequestTest.php
@@ -69,6 +69,20 @@ class UpdateProfileCardRequestTest extends TestCase
         $this->assertSame($card['firstName'] . ' ' . $card['lastName'], $data['card']['name']);
     }
 
+    public function testToken()
+    {
+        $this->request->setProfileId('8F10Ab54FC434b71972cF2E442c0fb4f');
+        $this->request->setCardId('1');
+        $token = array(
+            'name' => 'token-test-name',
+            'code' => 'token-test-code'
+        );
+        $this->assertSame($this->request, $this->request->setToken($token));
+        $this->assertSame($token, $this->request->getToken());
+        $data = $this->request->getData();
+        $this->assertSame($token, $data['token']);
+    }
+
     public function testHttpMethod()
     {
         $this->assertSame('PUT', $this->request->getHttpMethod());

--- a/tests/Message/UpdateProfileCardRequestTest.php
+++ b/tests/Message/UpdateProfileCardRequestTest.php
@@ -26,6 +26,20 @@ class UpdateProfileCardRequestTest extends TestCase
         $this->assertSame('9ba60541d32648B1A3581670123dF2Ef', $response->getCustomerCode());
     }
 
+    public function testSendError()
+    {
+        $this->request->setProfileId('9ba60541d32648B1A3581670123dF2Ef');
+        $this->request->setCardId('1');
+        $card = $this->getValidCard();
+        $this->assertSame($this->request, $this->request->setCard($card));
+        $this->setMockHttpResponse('UpdateProfileCardFailure.txt');
+        $response = $this->request->send();
+        $this->assertFalse($response->isSuccessful());
+        $this->assertSame(19, $response->getCode());
+        $this->assertSame(3, $response->getCategory());
+        $this->assertSame('Customer information failed data validation', $response->getMessage());
+    }
+
     public function testEndpoint()
     {
         $this->assertSame($this->request, $this->request->setProfileId('1'));

--- a/tests/Message/UpdateProfileCardRequestTest.php
+++ b/tests/Message/UpdateProfileCardRequestTest.php
@@ -49,6 +49,12 @@ class UpdateProfileCardRequestTest extends TestCase
         $this->assertSame('https://www.beanstream.com/api/v1/profiles/' . $this->request->getProfileId() . '/cards/' . $this->request->getCardId(), $this->request->getEndpoint());
     }
 
+    public function testComment()
+    {
+        $this->assertSame($this->request, $this->request->setComment('test'));
+        $this->assertSame('test', $this->request->getComment());
+    }
+
     public function testCard()
     {
         $this->request->setProfileId('8F10Ab54FC434b71972cF2E442c0fb4f');

--- a/tests/Mock/UpdateProfileCardFailure.txt
+++ b/tests/Mock/UpdateProfileCardFailure.txt
@@ -1,0 +1,10 @@
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+    "code": 19,
+    "category": 3,
+    "message": "Customer information failed data validation",
+    "reference": null,
+    "details": []
+}

--- a/tests/Mock/UpdateProfileCardSuccess.txt
+++ b/tests/Mock/UpdateProfileCardSuccess.txt
@@ -11,7 +11,6 @@ Server: Microsoft-IIS/8.5
 X-AspNet-Version: 4.0.30319
 X-Powered-By: ASP.NET
 
-
 {
     "code": 1,
     "message": "Operation Successful",


### PR DESCRIPTION
## What's this PR do?
- nested the `CreditCard` data under the _card_ key
- moved validation of credit card only if there's card data set
- added _token_ key with value, if there's token data set
- added _comment_ key with value
- updates the Create and Update PaymentProfileCardRequest tests

Should follow [Bambora V1.0.5](https://dev.na.bambora.com/docs/references/payment_APIs/v1-0-5)

[ECDEV-1379](https://eventconnect.atlassian.net/browse/ECDEV-1379)

## How should this be manually tested?
1. On [roomroster.v2](https://github.com/RoomRoster/roomroster.v2) replace `lemonstand/omnipay-beanstream` with `roomroster/omnipay-beanstream`
1. Test that all _Payment Profile_ and _Payment Profile Card_ requests still work
1. Run `./vendor/bin/phpunit` (add `--verbose` if you want more details)

## Checklist
- [X] All breaking changes have been tested across mobile and web projects. Ex: schema changes
- [X] Has been stress tested. Ex: CSV upload can handle 5 rows or 500
- [X] Any commands that change schema / data will be ran on every server (Production, staging, sales) at the same time.